### PR TITLE
Remove all the DDS stuff

### DIFF
--- a/src/BoardView.cpp
+++ b/src/BoardView.cpp
@@ -484,15 +484,17 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 			draw->ChannelsSetCurrent(kChannelImages);
 
 			segments = trunc(psz);
-			if (segments < 8) segments = 8;
-			if (segments > 32) segments = 32;
+			if (segments < 8)
+				segments = 8;
+			if (segments > 32)
+				segments = 32;
 
 			switch (pin->type) {
-				case Pin::kPinTypeTestPad:
-					draw->AddCircleFilled( ImVec2(pos.x, pos.y), psz, color, segments);
-					break;
-				default:
-					draw->AddCircle( ImVec2(pos.x, pos.y), psz, color, segments);
+			case Pin::kPinTypeTestPad:
+				draw->AddCircleFilled(ImVec2(pos.x, pos.y), psz, color, segments);
+				break;
+			default:
+				draw->AddCircle(ImVec2(pos.x, pos.y), psz, color, segments);
 			}
 
 			if (show_text) {

--- a/src/BoardView.cpp
+++ b/src/BoardView.cpp
@@ -411,9 +411,6 @@ inline void BoardView::DrawOutline(ImDrawList *draw) {
 }
 
 inline void BoardView::DrawPins(ImDrawList *draw) {
-	ImTextureID filled_circle_tex = TextureIDs[0];
-	ImTextureID empty_circle_tex = TextureIDs[1];
-
 	// TODO: use pin->diameter
 	float psz = (float)m_pinDiameter * 0.5f * m_scale;
 
@@ -433,7 +430,6 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 		}
 
 		// color & text depending on app state & pin type
-		auto pin_texture = empty_circle_tex;
 		uint32_t color = m_colors.pinDefault;
 		uint32_t text_color = color;
 		bool show_text = false;
@@ -461,7 +457,6 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 
 			if (pin->type == Pin::kPinTypeTestPad) {
 				color = m_colors.pinTestPad;
-				// pin_texture = filled_circle_tex; // TODO
 				show_text = false;
 			}
 

--- a/src/imgui_impl_dx9.cpp
+++ b/src/imgui_impl_dx9.cpp
@@ -16,8 +16,6 @@
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 
-#include "platform.h"
-
 // Data
 static HWND g_hWnd = 0;
 static INT64 g_Time = 0;
@@ -128,7 +126,6 @@ void ImGui_ImplDX9_RenderDrawLists(ImDrawData *draw_data) {
 	g_pd3dDevice->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
 	g_pd3dDevice->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
 	g_pd3dDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
-	g_pd3dDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, D3DTEXF_LINEAR);
 
 	// Setup orthographic projection matrix
 	// Being agnostic of whether <d3dx9.h> or <DirectXMath.h> can be used, we aren't relying on
@@ -295,38 +292,6 @@ static bool ImGui_ImplDX9_CreateFontsTexture() {
 	return true;
 }
 
-typedef unsigned long u32;
-
-struct DDSPixelFormat {
-	u32 size;
-	u32 flags;
-	u32 fourCC;
-	u32 rgbBitCount;
-	u32 rBitMask;
-	u32 gBitMask;
-	u32 bBitMask;
-	u32 aBitMask;
-};
-
-struct DDSHeader {
-	u32 magic;
-	u32 size;
-	u32 flags;
-	u32 height;
-	u32 width;
-	u32 pitchOrLinearSize;
-	u32 depth;
-	u32 mipMapCount;
-	u32 reserved1[11];
-	DDSPixelFormat pf;
-	u32 caps;
-	u32 caps2;
-	u32 caps3;
-	u32 caps4;
-	u32 reserved2;
-};
-
-
 bool ImGui_ImplDX9_CreateDeviceObjects() {
 	if (!g_pd3dDevice)
 		return false;
@@ -349,13 +314,6 @@ void ImGui_ImplDX9_InvalidateDeviceObjects() {
 	if (LPDIRECT3DTEXTURE9 tex = (LPDIRECT3DTEXTURE9)ImGui::GetIO().Fonts->TexID) {
 		tex->Release();
 		ImGui::GetIO().Fonts->TexID = 0;
-	}
-	for (int i = 0; i < NUM_GLOBAL_TEXTURES; i++) {
-		LPDIRECT3DTEXTURE9 tex = (LPDIRECT3DTEXTURE9)TextureIDs[i];
-		if (tex) {
-			tex->Release();
-			TextureIDs[i] = 0;
-		}
 	}
 	g_FontTexture = NULL;
 }

--- a/src/imgui_impl_dx9.cpp
+++ b/src/imgui_impl_dx9.cpp
@@ -126,6 +126,7 @@ void ImGui_ImplDX9_RenderDrawLists(ImDrawData *draw_data) {
 	g_pd3dDevice->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
 	g_pd3dDevice->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
 	g_pd3dDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
+	g_pd3dDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, D3DTEXF_LINEAR);
 
 	// Setup orthographic projection matrix
 	// Being agnostic of whether <d3dx9.h> or <DirectXMath.h> can be used, we aren't relying on

--- a/src/platform.h
+++ b/src/platform.h
@@ -14,6 +14,3 @@ char *file_as_buffer(size_t *buffer_size, const char *utf8_filename);
 char *show_file_picker();
 
 unsigned char *LoadAsset(int *asset_size, int asset_id);
-
-#define NUM_GLOBAL_TEXTURES 10
-extern ImTextureID TextureIDs[NUM_GLOBAL_TEXTURES];

--- a/src/platform_unix.cpp
+++ b/src/platform_unix.cpp
@@ -79,6 +79,4 @@ char *show_file_picker() {
 
 #endif // ! __APPLE__
 
-ImTextureID TextureIDs[NUM_GLOBAL_TEXTURES];
-
 #endif // ! _WIN32

--- a/src/platform_win32.cpp
+++ b/src/platform_win32.cpp
@@ -88,6 +88,4 @@ unsigned char *LoadAsset(int *asset_size, int asset_id) {
 	return data;
 }
 
-ImTextureID TextureIDs[NUM_GLOBAL_TEXTURES];
-
 #endif // _WIN32


### PR DESCRIPTION
- Reset `imgui_impl_dx9.cpp` back to the stock example from imgui
- Remove `TextureIDs[]`

Tested on windows

Once this is pulled into dds-replacement, OpenBoardView/OpenBoardView#29 should be ready to be merged into master.